### PR TITLE
[web] Handle the StatusChanged element

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -59,7 +59,8 @@ function App() {
         loadStorage(dispatch);
       }
 
-      if (changedKeys.includes("Status")) {
+      // FIXME: use the status_id from the event
+      if (payload.event == "StatusChanged") {
         loadInstallation(dispatch);
       }
 


### PR DESCRIPTION
Honor the `StatusChanged` event. The proper solution should be to use the `status_id` which is included in the event. But, until we merge status and progress, I will keep the change as small as possible.